### PR TITLE
Fix memory leak with Update page

### DIFF
--- a/src/pages/create/Create.test.js
+++ b/src/pages/create/Create.test.js
@@ -5,32 +5,31 @@ import userEvent from '@testing-library/user-event'
 import { createIncident } from '../../api/index'
 
 jest.mock('../../api/index', () => {
-    const originalModule = jest.requireActual('../../api/index')
-    return {
-        ...originalModule,
-        createIncident: jest.fn()
-    }
+  const originalModule = jest.requireActual('../../api/index')
+  return {
+    ...originalModule,
+    createIncident: jest.fn(),
+  }
 })
 
-describe('Create', () =>{
-    it('should allow the user to create a new Incident', async () => {
-        const history = {replace: jest.fn()}
-        const {getByLabelText, getByText} = render(<Create history={history}/>)
-        userEvent.type(getByLabelText('Title'), 'Whoo hoo!')
-        userEvent.type(getByLabelText('Description'), 'Dancing Elvis')
-        userEvent.click(getByLabelText('flights'))
-        createIncident.mockResolvedValueOnce()
+describe('Create', () => {
+  it('should allow the user to create a new Incident', async () => {
+    const history = { replace: jest.fn() }
+    const { getByLabelText, getByText } = render(<Create history={history} />)
+    userEvent.type(getByLabelText('Title'), 'Whoo hoo!')
+    userEvent.type(getByLabelText('Description'), 'Dancing Elvis')
+    userEvent.click(getByLabelText('flights'))
+    createIncident.mockResolvedValueOnce()
 
-        userEvent.click(getByText('Create incident'))
-        expect(createIncident).toHaveBeenCalledTimes(1)
-        expect(createIncident).toHaveBeenCalledWith(
-            {
-                "description": "Dancing Elvis",
-                "services": ["flights"],
-                "title": "Whoo hoo!",
-                "type": "degraded"
-            })
-        await wait(() => expect(history.replace).toHaveBeenCalledWith('/'))
-        expect(history.replace).toHaveBeenCalledTimes(1)
+    userEvent.click(getByText('Create incident', { selector: 'button' }))
+    expect(createIncident).toHaveBeenCalledTimes(1)
+    expect(createIncident).toHaveBeenCalledWith({
+      description: 'Dancing Elvis',
+      services: ['flights'],
+      title: 'Whoo hoo!',
+      type: 'degraded',
     })
+    await wait(() => expect(history.replace).toHaveBeenCalledWith('/'))
+    expect(history.replace).toHaveBeenCalledTimes(1)
+  })
 })

--- a/src/pages/home/Home.test.js
+++ b/src/pages/home/Home.test.js
@@ -1,14 +1,10 @@
-import { render, cleanup, waitForElement } from '@testing-library/react'
+import { render, waitForElement } from '@testing-library/react'
 import React from 'react'
 import { MemoryRouter } from 'react-router-dom'
-import 'jest-dom/extend-expect'
 import Home from './Home'
 import { getAllIncidents } from '../../api/index'
 
 jest.mock('../../api/index')
-
-beforeEach(cleanup)
-beforeEach(jest.clearAllMocks)
 
 const incidentFabricator = type => {
   return {
@@ -21,7 +17,7 @@ const incidentFabricator = type => {
         timestamp: {
           seconds: 1560851458,
           nanoseconds: 593000000,
-          toDate: () => new Date(1560851458)
+          toDate: () => new Date(1560851458),
         },
         type: 'investigating',
       },
@@ -41,7 +37,7 @@ const resolvedIncidentFabricator = () => {
         timestamp: {
           seconds: 1560851458,
           nanoseconds: 593000000,
-          toDate: () => new Date(1560851458)
+          toDate: () => new Date(1560851458),
         },
         type: 'resolved',
       },
@@ -57,7 +53,11 @@ describe('Home', () => {
       getAllIncidents.mockImplementationOnce(fn =>
         setTimeout(() => fn([incidentFabricator(state)]), 0)
       )
-      const { getByText } = render(<MemoryRouter><Home /></MemoryRouter>)
+      const { getByText } = render(
+        <MemoryRouter>
+          <Home />
+        </MemoryRouter>
+      )
       expect(getByText('Loading ...')).toBeInTheDocument()
       await waitForElement(() => getByText(`Service is: ${state}`))
 
@@ -69,7 +69,11 @@ describe('Home', () => {
     getAllIncidents.mockImplementationOnce(fn =>
       setTimeout(() => fn([resolvedIncidentFabricator()]), 0)
     )
-    const { getByText } = render(<MemoryRouter><Home /></MemoryRouter> )
+    const { getByText } = render(
+      <MemoryRouter>
+        <Home />
+      </MemoryRouter>
+    )
     expect(getByText('Loading ...')).toBeInTheDocument()
     await waitForElement(() => getByText(`Service is: stable`))
 

--- a/src/pages/update/Update.tsx
+++ b/src/pages/update/Update.tsx
@@ -23,7 +23,8 @@ const Update = (props: Props) => {
     props.history.replace('/')
   }
   useEffect(() => {
-    getIncident(props.match.params.id, setIncident)
+    const unsubscribe = getIncident(props.match.params.id, setIncident)
+    return unsubscribe
   }, [props.match.params.id])
 
   if (!incident) return <div>Loading</div>

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,0 +1,4 @@
+import 'jest-dom/extend-expect'
+import '@testing-library/react/cleanup-after-each'
+
+beforeEach(jest.clearAllMocks)


### PR DESCRIPTION
The `Create` page was connecting to the API and receiving updates whenever a change occurred. This kept happening even after the page was unmounted. With this change, we unregister the listener when the page gets unmounted i.e. we navigate to a different page.